### PR TITLE
Pass additional options to xrsync command

### DIFF
--- a/porthos/root/etc/porthos/repos.conf
+++ b/porthos/root/etc/porthos/repos.conf
@@ -14,3 +14,7 @@ repos[7.4.1708/centos-sclo-sclo/x86_64]=rsync://mirror.rackspace.com/centos/7.4.
 repos[7.4.1708/centos-sclo-rh/x86_64]=rsync://mirror.rackspace.com/centos/7.4.1708/sclo/x86_64/rh
 repos[7.4.1708/nethserver-base/x86_64]=rsync://packages.nethserver.org/nethserver/7.4.1708/base/x86_64
 repos[7.4.1708/nethserver-updates/x86_64]=rsync://packages.nethserver.org/nethserver/7.4.1708/updates/x86_64
+
+declare -A options
+
+options[7.4.1708/epel/x86_64]="--exclude=debug"

--- a/porthos/root/usr/local/bin/repo-tier-pull
+++ b/porthos/root/usr/local/bin/repo-tier-pull
@@ -48,4 +48,4 @@ fi
 
 mkdir -p ${backup_dir}
 touch ${dest_dir}/head
-exec /usr/local/bin/xrsync ${repos[$repo_id]}/ ${head_dir} --delete-after --backup --backup-dir=${backup_dir}
+exec /usr/local/bin/xrsync ${repos[$repo_id]}/ ${head_dir} --delete-after --backup --backup-dir=${backup_dir} ${options[$repo_id]}


### PR DESCRIPTION
Exclude epel/debug directory in porthos config

https://github.com/nethesis/nethinfra/issues/29