### PR TITLE
Fix autoupdate/ snapshot lookup for old NS versions

### DIFF
--- a/porthos/README.md
+++ b/porthos/README.md
@@ -52,6 +52,26 @@ Restart nginx:
 
     systemctl restart nginx
 
+## Filesystem structure
+
+Repository files are stored under
+`/srv/porthos/webroot/head/<nsversion>/<repo>/<arch>`. The `<nsversion>`
+component can be a symlink to another version directory. For instance
+
+    /srv/porthos/webroot/head/6.10/nethserver-updates/x86_64
+
+The old `6.9` version number can be a symlink:
+
+    /srv/porthos/webroot/head/6.9 -> 6.10
+
+Repository snapshots are prefixed as `/srv/porthos/webroot/head/d<YYYYMMDD>`.
+For instance
+
+    /srv/porthos/webroot/d20190809/6.10/nethserver-updates/x86_64
+
+If a version symlink is set under `head/` it is considered valid also for
+snapshots. See the `resolve_version_symlinks()` PHP function in `lib.php`.
+
 ## YUM client
 
 Mirrorlist query format
@@ -149,7 +169,9 @@ from `/etc/porthos/repos.conf`. Upstream YUM rsync URLs are defined there.
 The following commands are executed automatically, as defined in `porthos.cron`:
 
 - `repo-bulk-pull` creates a snapshot date-dir (e.g. `d20180301`) under
-  `dest_dir` with differences from upstream repositories.
+  `dest_dir` with differences from upstream repositories.  Ensure `dest_dir`
+  parameter for Bash scripts has the same value of PHP `$config['root_dir']`
+  (default is `/srv/porthos/webroot/`, with trailing slash for PHP).
 - `repo-bulk-cleanup` erases stale snapshots directories
 
 The following commands are designed for Porthos initialization, to recover from errors, or implement low-level actions:

--- a/porthos/root/srv/porthos/script/auth.php
+++ b/porthos/root/srv/porthos/script/auth.php
@@ -74,10 +74,11 @@ if($access['tier_id'] < 0) {
 }
 
 $is_tier_request = is_numeric($tier_id) && $uri['prefix'] == 'autoupdate';
+$real_full_path = resolve_version_symlinks($uri['full_path']);
 if($is_tier_request && $valid_credentials) {
     // Seeking a snapshot is a time-consuming op. Ensure we have valid
     // credentials before running it!
-    $snapshot = lookup_snapshot($uri['full_path'], $tier_id, $config['week_size']);
+    $snapshot = lookup_snapshot($real_full_path, $tier_id, $config['week_size']);
 } else {
     $snapshot = 'head';
 }
@@ -107,4 +108,4 @@ if (! $valid_credentials) {
 }
 
 header('Cache-Control: private');
-return_file('/' . $snapshot . $uri['full_path']);
+return_file('/' . $snapshot . $real_full_path);

--- a/porthos/root/srv/porthos/script/config-porthos.php
+++ b/porthos/root/srv/porthos/script/config-porthos.php
@@ -55,3 +55,7 @@ $config['week_size'] = 5;
 // timezone (string)
 //     the PHP timezone for this application
 $config['timezone'] = 'UTC';
+
+// root_path (string)
+//     absolute path to porthos web root directory, with trailing slash
+$config['root_path'] = '/srv/porthos/webroot/';

--- a/porthos/root/srv/porthos/script/lib.php
+++ b/porthos/root/srv/porthos/script/lib.php
@@ -80,7 +80,7 @@ function get_snapshot_timestamp($snapshot_name) {
 }
 
 function lookup_snapshot($path, $tier_id = 0, $week_size = 5) {
-    $root_path = "/srv/porthos/webroot/";
+    $root_path = $config['root_path'] ?: '/srv/porthos/webroot/';
     $snapshots = array_reverse(array_map('basename', glob($root_path . "d20*")));
     $last_snapshot_day_id = date('w', get_snapshot_timestamp($snapshots[0]));
     // $monday_offset formula:
@@ -93,4 +93,17 @@ function lookup_snapshot($path, $tier_id = 0, $week_size = 5) {
         }
     }
     return $i < 0 ? 'head' : $snapshots[$i];
+}
+
+function resolve_version_symlinks($full_path) {
+    $version = substr($full_path, 0, strpos($full_path, '/'));
+    if( ! $version) {
+        return $full_path;
+    }
+    $head_path = ($config['root_path'] ?: '/srv/porthos/webroot/') . 'head/';
+    $version_path = realpath($head_path . $version);
+    if( ! $version_path) {
+        return $full_path;
+    }
+    return basename($version_path) . substr($full_path, strpos($full_path, '/'));
 }


### PR DESCRIPTION


Symlinks from old releases (i.e. `7.5.1804` -> `7.6.1810`) do not work with `lookup_snapshot()`: when a file in `autoupdate/7.5.1804` is requested it is always returned from `head/` because the version symlink is not present under snapshot dirs.


The new `resolve_version_symlinks()` substitutes the version symlink with a real directory name for `lookup_snapshot()`.