### PR TITLE
porthos. Stop autoupdate/ contents distribution

### DIFF
--- a/porthos/root/srv/porthos/script/config-porthos.php
+++ b/porthos/root/srv/porthos/script/config-porthos.php
@@ -56,7 +56,7 @@ $config['week_size'] = 5;
 //     the PHP timezone for this application
 $config['timezone'] = 'UTC';
 
-// stop_autoupdate (boolean)
-//     forcibly stop autoupdate contents distribution. The /empty repository
-//     is served instead.
-$config['stop_autoupdate'] = FALSE;
+// stop_autoupdate (array)
+//     forcibly stop autoupdate contents distribution for the listed versions.
+//     The /empty repository is served instead.
+$config['stop_autoupdate'] = array();

--- a/porthos/root/srv/porthos/script/config-porthos.php
+++ b/porthos/root/srv/porthos/script/config-porthos.php
@@ -55,3 +55,8 @@ $config['week_size'] = 5;
 // timezone (string)
 //     the PHP timezone for this application
 $config['timezone'] = 'UTC';
+
+// stop_autoupdate (boolean)
+//     forcibly stop autoupdate contents distribution. The /empty repository
+//     is served instead.
+$config['stop_autoupdate'] = FALSE;

--- a/porthos/root/srv/porthos/script/mirrorlist.php
+++ b/porthos/root/srv/porthos/script/mirrorlist.php
@@ -52,7 +52,7 @@ if($system_id) {
 }
 
 foreach($config['base_urls'] as $baseurl) {
-    if($use_tier && $config['stop_autoupdate']) {
+    if($use_tier && in_array($version, $config['stop_autoupdate'])) {
         echo $baseurl . "empty\n";
     } else {
         echo $baseurl . $path . "${version}/${repo}/${arch}\n";

--- a/porthos/root/srv/porthos/script/mirrorlist.php
+++ b/porthos/root/srv/porthos/script/mirrorlist.php
@@ -52,5 +52,9 @@ if($system_id) {
 }
 
 foreach($config['base_urls'] as $baseurl) {
-    echo $baseurl . $path . "${version}/${repo}/${arch}\n";
+    if($use_tier && $config['stop_autoupdate']) {
+        echo $baseurl . "empty\n";
+    } else {
+        echo $baseurl . $path . "${version}/${repo}/${arch}\n";
+    }
 }


### PR DESCRIPTION
Forcibly stop autoupdate contents distribution. The `/empty` repository is served instead. Ensure the correct metadata is present along with `repomd.xml.asc` signature possibly.