### PR TITLE
Fix repo-head-rollback command

### DIFF
--- a/porthos/README.md
+++ b/porthos/README.md
@@ -191,23 +191,23 @@ The following commands are designed for Porthos initialization, to recover from 
 
 - `repo-bulk-hinit` runs initial synchronization from upstream repositories (-f disables the check for already existing directories)
 - `repo-head-init`  synchronization of head from a specific upstream repo
-- `repo-head-rollback` roll back a repository head state to a previous snapshot state
+- `repo-head-rollback` rolls back a repository to its latest snapshot
 - `repo-snapshot-create` create a new repository snapshot
 - `repo-snapshot-delete` delete repomd.xml from a given repository snapshot
 - `repo-rpm-lookup`  seek the given RPM in every snapshot for a given repository
 - `xrsync` run rsync safely, trying to repeat the operation if it fails
 
-A **rollback action** for a given repository consists into seeking the
-most recent snapshot and moving it back to the head position. YUM metadata and
-removed RPMs are merged, reverting the head to the past snapshot state. For
-instance:
+A **rollback action** for a given repository consists into reverting its most
+recent snapshot state, by moving the snapshot YUM metadata and removed/changed
+RPMs to the head position. For instance:
 
-    repo-head-rollback 7.6.1810/nethserver-updates/x86_64
+    repo-head-rollback 7.7.1908/nethserver-updates/x86_64 -n
 
-The command above rolls back the `head/` directory to the most recent, non-empty
-snapshot of `nethserver-updates`. The command can be invoked multiple times, but
-it fails as soon as no snapshot is found, or if an invalid repository identifier
-is issued.
+The command above attempts to roll back the `head/` directory to the most
+recent, non-empty snapshot of `nethserver-updates`. The command can be invoked
+multiple times, but it fails as soon as no snapshot is found, or if an invalid
+repository identifier is issued. Remove the `-n` flag (rsync dry run) to
+actually change the files.
 
 Some times it is desirable to re-sync the head repository, without generating a
 new snapshot, like `repo-snapshot-create` does. That happens if an upstream repo

--- a/porthos/root/usr/local/bin/repo-head-rollback
+++ b/porthos/root/usr/local/bin/repo-head-rollback
@@ -20,6 +20,8 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+shopt -s nullglob extglob
+
 function exit_help ()
 {
     echo -e "Usage:\n  $(basename "$0") REPO_ID [additional rsync opts]" 1>&2
@@ -37,20 +39,23 @@ if [[ -z ${repo_id} || -z ${repos[$repo_id]} ]]; then
     exit_help;
 fi
 
-tiers=( t[0-9] )
+snapshots=( d+([0-9])"/${repo_id}/repodata/repomd.xml" )
 
-for tier in "${tiers[@]}"; do
-    if [[ -f ${tier}/${repo_id}/repodata/repomd.xml ]]; then
-        rsync --remove-source-files -ai "${@}" ${tier}/${repo_id}/ head/${repo_id}
-        if [[ $? == 0 ]]; then
-            echo "[NOTICE] ${repo_id} repository was rolled back to snapshot $(readlink ${tier}) (${tier})"
-            exit 0
-        else
-            echo "[ERROR] rsync error" 1>&2
-            exit 1
-        fi
+((${#snapshots[@]} > 0)) && snapshot="${snapshots[-1]%%/*}"
+
+if [[ -z ${snapshot} ]]; then
+    echo "[ERROR] Cannot find any past snapshot of ${repo_id}. Aborted." 1>&2
+    exit 1
+fi
+
+if [[ -f ${snapshot}/${repo_id}/repodata/repomd.xml ]]; then
+    rsync --remove-source-files -ai "${@}" "${snapshot}/${repo_id}/" "head/${repo_id}"
+    if [[ $? != 0 ]]; then
+        echo "[ERROR] rsync error" 1>&2
+        exit 1
     fi
-done
+fi
 
-echo "[ERROR] Cannot find any past snapshot of ${repo_id}. Aborted." 1>&2
-exit 1
+timestamp=$(stat -c %y "head/${repo_id}/repodata/repomd.xml")
+echo "[NOTICE] ${repo_id} repository was rolled back to snapshot ${snapshot} (repomd.xml ${timestamp})"
+exit 0


### PR DESCRIPTION
The old implementation was still relying on symlinks.