### PR TITLE
athos & foil. create command to send expiration mails

### DIFF
--- a/athos/configuration/configuration.go
+++ b/athos/configuration/configuration.go
@@ -31,11 +31,12 @@ import (
 )
 
 type Notifications struct {
-	PortalUrl   string `json:"portal_url"`
-	HelpUrl     string `json:"help_url"`
-	DocsUrl     string `json:"docs_url"`
-	PortalTitle string `json:"portal_title"`
-	Email       struct {
+	PortalUrl    string `json:"portal_url"`
+	HelpUrl      string `json:"help_url"`
+	DocsUrl      string `json:"docs_url"`
+	CommunityUrl string `json:"community_url"`
+	PortalTitle  string `json:"portal_title"`
+	Email        struct {
 		From         string `json:"from"`
 		SMTPHost     string `json:"smtp_host"`
 		SMTPPort     int    `json:"smtp_port"`
@@ -53,17 +54,17 @@ type Configuration struct {
 		Password string `json:"password"`
 	} `json:"database"`
 	Redis struct {
-		Host  string `json:"host"`
-		Port  string `json:"port"`
+		Host string `json:"host"`
+		Port string `json:"port"`
 	} `json:"redis"`
-	Cors       struct {
+	Cors struct {
 		Headers []string `json:"headers"`
 		Origins []string `json:"origins"`
 		Methods []string `json:"methods"`
 	} `json:"cors"`
 	Auth0 struct {
-		Domain        string `json:"domain"`
-		Audience      string `json:"audience"`
+		Domain   string `json:"domain"`
+		Audience string `json:"audience"`
 	} `json:"auth0"`
 	PayPal struct {
 		ClientID     string `json:"client_id"`
@@ -71,7 +72,7 @@ type Configuration struct {
 		Sandbox      bool   `json:"sandbox"`
 	} `json:"paypal"`
 	Log struct {
-		Level        string `json:"level"`
+		Level string `json:"level"`
 	} `json:"log"`
 	Billing struct {
 		Country string `json:"country"`

--- a/athos/notifications/mail.go
+++ b/athos/notifications/mail.go
@@ -23,6 +23,8 @@ package notifications
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	gomail "gopkg.in/gomail.v2"
@@ -30,6 +32,7 @@ import (
 	"github.com/cbroglie/mustache"
 	"github.com/nethesis/dartagnan/athos/configuration"
 	"github.com/nethesis/dartagnan/athos/models"
+	"github.com/nethesis/dartagnan/athos/utils"
 	"github.com/nicksnyder/go-i18n/i18n"
 )
 
@@ -94,7 +97,76 @@ func alertTextBody(alert models.Alert) string {
 	return text
 }
 
-func MailNotification(address string, alert models.Alert, isNew bool) bool {
+func expireHtmlBody(system models.System, period string) string {
+	values := make(map[string]string)
+	T, _ := i18n.Tfunc("en-US", "en-US", "en-US")
+
+	values["hello"] = T("hello")
+	values["year"] = strconv.Itoa(time.Now().Year())
+
+	values["title"] = configuration.Config.Notifications.PortalTitle
+	values["urlComm"] = configuration.Config.Notifications.CommunityUrl
+	values["urlDocs"] = configuration.Config.Notifications.DocsUrl
+	values["urlHelp"] = configuration.Config.Notifications.HelpUrl
+
+	values["systemUUID"] = T("server_uuid")
+	values["serverName"] = system.UUID
+	values["serverDetails"] = fmt.Sprintf(fmt.Sprintf("%s/servers/%d", configuration.Config.Notifications.PortalUrl, system.ID))
+
+	values["footerMessage"] = T("footer_message")
+
+	renderFile := ""
+	if system.Subscription.SubscriptionPlan.Code == "trial" {
+		values["message"] = T(period + "_trial")
+		values["serverDetailsMessage"] = T("server_link")
+
+		renderFile = "templates/expiration-template-trial.mustache"
+	} else {
+		values["message"] = T(period+"_others", map[string]interface{}{
+			"Subscription": system.Subscription.SubscriptionPlan.Name,
+		})
+		values["serverDetailsMessage"] = T("server_link_renew")
+		values["ownerName"] = utils.GetBillingInfo(system.CreatorID).Name
+
+		renderFile = "templates/expiration-template-others.mustache"
+	}
+
+	output, err := mustache.RenderFile(renderFile, values)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return output
+}
+
+func expireTextBody(system models.System, period string) string {
+	T, _ := i18n.Tfunc("en-US", "en-US", "en-US")
+
+	text := fmt.Sprintf("***** %s ***** \n\n", configuration.Config.Notifications.PortalTitle)
+	text += fmt.Sprintf("%s: %s\n", T("server_uuid"), system.UUID)
+	text += fmt.Sprintf("%s: %s\n", T("subscription"), system.Subscription.SubscriptionPlan.Name)
+
+	message := ""
+	if system.Subscription.SubscriptionPlan.Code == "trial" {
+		message = T(period + "_trial_plain")
+
+	} else {
+		message = T(period+"_others_plain", map[string]interface{}{
+			"Subscription": system.Subscription.SubscriptionPlan.Name,
+			"Name":         utils.GetBillingInfo(system.CreatorID).Name,
+		})
+	}
+
+	text += "\n" + message
+	text += fmt.Sprintf("\n%s\n", fmt.Sprintf(fmt.Sprintf("%s/servers/%d", configuration.Config.Notifications.PortalUrl, system.ID)))
+
+	text += fmt.Sprintf("\n%s: %s\n", "Blog", configuration.Config.Notifications.CommunityUrl)
+	text += fmt.Sprintf("%s: %s\n", "Support", strings.Split(configuration.Config.Notifications.HelpUrl, ":")[1])
+	text += fmt.Sprintf("%s: %s\n", "Docs", configuration.Config.Notifications.DocsUrl)
+	return text
+}
+
+func MailNotificationAlert(address string, alert models.Alert, isNew bool) bool {
 	i18n.MustLoadTranslationFile("templates/en-US-alert.json")
 	T, _ := i18n.Tfunc("en-US", "en-US", "en-US")
 	status := true
@@ -112,6 +184,35 @@ func MailNotification(address string, alert models.Alert, isNew bool) bool {
 	}
 
 	m.AddAlternative("text/html", alertHtmlBody(alert))
+
+	d := gomail.NewDialer(
+		configuration.Config.Notifications.Email.SMTPHost,
+		configuration.Config.Notifications.Email.SMTPPort,
+		configuration.Config.Notifications.Email.SMTPUser,
+		configuration.Config.Notifications.Email.SMTPPassword,
+	)
+
+	// send the email
+	if err := d.DialAndSend(m); err != nil {
+		status = false
+	}
+
+	return status
+}
+
+func MailNotificationExpire(address string, system models.System, period string) bool {
+	i18n.MustLoadTranslationFile("templates/en-US-alert.json")
+	T, _ := i18n.Tfunc("en-US", "en-US", "en-US")
+	status := true
+	m := gomail.NewMessage()
+	m.SetHeader("From", configuration.Config.Notifications.Email.From)
+	m.SetHeader("To", address)
+	subject := fmt.Sprintf("[%s][%s] %s", T("expiration"), system.Subscription.SubscriptionPlan.Name, T(system.UUID))
+	m.SetHeader("Subject", subject)
+	m.SetBody("text/plain", expireTextBody(system, period))
+	m.SetHeader("Message-Id", fmt.Sprintf("%d@dartagnan.project", time.Now().UnixNano()))
+
+	m.AddAlternative("text/html", expireHtmlBody(system, period))
 
 	d := gomail.NewDialer(
 		configuration.Config.Notifications.Email.SMTPHost,

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -121,7 +121,7 @@
   },
   {
     "id": "1w_others",
-    "translation": "<br>your <b>{{.Subscription}}</b> subscription will expire in <b>1 week</b>.<br><br>If you are enjoining it and you want to still have access to stable repositories, renew your subscription clicking the button below:"
+    "translation": "<br>your <b>{{.Subscription}}</b> subscription will expire in <b>1 week</b>.<br><br>If you are enjoying it and you want to still have access to stable repositories, renew your subscription clicking the button below:"
   },
   {
     "id": "1d_others",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -145,7 +145,7 @@
   },
   {
     "id": "1d_others_plain",
-    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, renew your subscription now by clicking the button below:"
+    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, renew your subscription now by clicking the link below:"
   },
   {
     "id": "server_link",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -113,7 +113,7 @@
   },
   {
     "id": "1w_trial",
-    "translation": "<br>your trial subscription will expire in <b>1 week</b>.<br><br>If you are enjoining it and you want to still have access to stable repositories, buy a subscription clicking the button below:"
+    "translation": "<br>your trial subscription will expire in <b>1 week</b>.<br><br>If you are enjoining it and you want to still have access to stable repositories, buy a subscription by clicking the button below:"
   },
   {
     "id": "1d_trial",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -1,4 +1,5 @@
-[{
+[
+  {
     "id": "Alert report",
     "translation": "Alert report"
   },
@@ -93,5 +94,73 @@
   {
     "id": "alert_nut",
     "translation": "UPS on battery"
+  },
+  {
+    "id": "hello",
+    "translation": "Hello"
+  },
+  {
+    "id": "expiration",
+    "translation": "EXPIRATION"
+  },
+  {
+    "id": "subscription",
+    "translation": "Subscription"
+  },
+  {
+    "id": "2w_trial",
+    "translation": "<br>thank you for joining our Subscription trial program.<br><br>Your trial subscription will expire in <b>2 weeks</b>, we hope that everything is still up and running!<br><br>If you need help, remember to join our vibrant <a target=\"blank\" href=\"https://community.nethserver.org\">Community</a><br><br>· Would you like to secure your installation thanks to stable repositories?<br>· Do you want to sponsor the NethServer project?<br><br>Click on the button below and buy a subscription:"
+  },
+  {
+    "id": "1w_trial",
+    "translation": "<br>your trial subscription will expire in <b>1 week</b>.<br><br>If you are enjoining it and you want to still have access to stable repositories, buy a subscription clicking the button below:"
+  },
+  {
+    "id": "1d_trial",
+    "translation": "<br>your trial subscription will expire <b>tomorrow</b>!<br><br>After subscription expiration, the server <b>will not be able</b> to download updates.<br><br>If you want to leave the subscription program, remember to unregister your machine following the <a href=\"https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription\">documentation</a>.<br><br>Otherwise, if you are still interested in accessing the stable repositories, buy a subscription now by clicking the button below:"
+  },
+  {
+    "id": "1w_others",
+    "translation": "<br>your <b>{{.Subscription}}</b> subscription will expire in <b>1 week</b>.<br><br>If you are enjoining it and you want to still have access to stable repositories, renew your subscription clicking the button below:"
+  },
+  {
+    "id": "1d_others",
+    "translation": "<br>your <b>{{.Subscription}}</b> subscription will expire <b>tomorrow</b>!<br><br>After subscription expiration, the server <b>will not be able</b> to download updates.<br><br>If you want to leave the subscription program, remember to unregister your machine following the <a href=\"https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription\">documentation</a>.<br><br>Otherwise, if you are still interested in accessing the stable repositories, renew your subscription now by clicking the button below:"
+  },
+  {
+    "id": "2w_trial_plain",
+    "translation": "Hi,\nthank you for joining our Subscription trial program.\n\nYour trial subscription will expire in 2 weeks, we hope that everything is still up and running!\n\nIf you need help, remember to join our vibrant community at: https://community.nethserver.org\n\n· Would you like to secure your installation thanks to stable repositories?\n· Do you want to sponsor the NethServer project?\n\nClick on the button below and buy a subscription:"
+  },
+  {
+    "id": "1w_trial_plain",
+    "translation": "Hi,\nyour trial subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, buy a subscription clicking the button below:"
+  },
+  {
+    "id": "1d_trial_plain",
+    "translation": "Hi,\nyour trial subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, buy a subscription now by clicking the button below:"
+  },
+  {
+    "id": "1w_others_plain",
+    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, renew your subscription clicking the button below:"
+  },
+  {
+    "id": "1d_others_plain",
+    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, renew your subscription now by clicking the button below:"
+  },
+  {
+    "id": "server_link",
+    "translation": "Upgrade your plan"
+  },
+  {
+    "id": "server_link_renew",
+    "translation": "Renew your plan"
+  },
+  {
+    "id": "server_uuid",
+    "translation": "System"
+  },
+  {
+    "id": "footer_message",
+    "translation": "Still convinced to not buy a subscription? <a href=\"mailto:support@nethserver.com\">Tell us</a> why and how can we improve our offer!<br><br>Thank you,<br>NethServer Subscription team"
   }
 ]

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -137,7 +137,7 @@
   },
   {
     "id": "1d_trial_plain",
-    "translation": "Hi,\nyour trial subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, buy a subscription now by clicking the button below:"
+    "translation": "Hi,\nyour trial subscription will expire tomorrow!\n\nAfter subscription expiration, the server will not be able to download updates.\n\nIf you want to leave the subscription program, remember to unregister your machine following the documentation at: https://docs.nethserver.org/en/v7/subscription.html#removing-a-subscription.\n\nOtherwise, if you are still interested in accessing the stable repositories, buy a subscription now by clicking the link below:"
   },
   {
     "id": "1w_others_plain",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -141,7 +141,7 @@
   },
   {
     "id": "1w_others_plain",
-    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, renew your subscription clicking the button below:"
+    "translation": "Hi {{.Name}},\nyour {{.Subscription}} subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, renew your subscription by clicking the link below:"
   },
   {
     "id": "1d_others_plain",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -129,7 +129,7 @@
   },
   {
     "id": "2w_trial_plain",
-    "translation": "Hi,\nthank you for joining our Subscription trial program.\n\nYour trial subscription will expire in 2 weeks, we hope that everything is still up and running!\n\nIf you need help, remember to join our vibrant community at: https://community.nethserver.org\n\n· Would you like to secure your installation thanks to stable repositories?\n· Do you want to sponsor the NethServer project?\n\nClick on the button below and buy a subscription:"
+    "translation": "Hi,\nthank you for joining our Subscription trial program.\n\nYour trial subscription will expire in 2 weeks, we hope that everything is still up and running!\n\nIf you need help, remember to join our vibrant community at: https://community.nethserver.org\n\n· Would you like to secure your installation thanks to stable repositories?\n· Do you want to sponsor the NethServer project?\n\nClick on the link below and buy a subscription:"
   },
   {
     "id": "1w_trial_plain",

--- a/athos/templates/en-US-alert.json
+++ b/athos/templates/en-US-alert.json
@@ -133,7 +133,7 @@
   },
   {
     "id": "1w_trial_plain",
-    "translation": "Hi,\nyour trial subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, buy a subscription clicking the button below:"
+    "translation": "Hi,\nyour trial subscription will expire in 1 week.\n\nIf you are enjoining it and you want to still have access to stable repositories, buy a subscription by clicking the link below:"
   },
   {
     "id": "1d_trial_plain",

--- a/athos/templates/expiration-template-others.mustache
+++ b/athos/templates/expiration-template-others.mustache
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>{{title}}</title>
+</head>
+
+<body>
+
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <!--[if !mso]><!-->
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <!--<![endif]-->
+
+        <style type="text/css">
+            .ReadMsgBody {
+                width: 100%;
+                background-color: #E1E1E1;
+            }
+
+            .ExternalClass {
+                width: 100%;
+                background-color: #E1E1E1;
+            }
+
+            body {
+                width: 100%;
+                background-color: #E1E1E1;
+                margin: 0;
+                padding: 0;
+                -webkit-font-smoothing: antialiased;
+                font-family: "Open Sans", Helvetica, Arial, sans-serif !important;
+                font-weight: 500;
+            }
+
+            table {
+                border-collapse: collapse !important;
+                mso-table-lspace: 0pt;
+                mso-table-rspace: 0pt;
+            }
+
+            @-ms-viewport {
+                width: device-width;
+            }
+
+            @media only screen and (max-width: 639px) {
+                .wrapper {
+                    width: 100%;
+                    padding: 0 !important;
+                }
+            }
+
+            @media only screen and (max-width: 480px) {
+                .centerClass {
+                    margin: 0 auto !important;
+                }
+
+                .imgClass {
+                    width: 100% !important;
+                    height: auto;
+                }
+
+                .wrapper {
+                    width: 320px !important;
+                    padding: 0 !important;
+                    overflow-x: hidden !important;
+                    border-collapse: separate !important;
+                }
+
+                .container {
+                    width: 320px !important;
+                    padding: 0 !important;
+                }
+
+                .mobile {
+                    width: 320px !important;
+                    display: block;
+                    padding: 0 !important;
+                    text-align: center !important;
+                }
+
+                .mobile-header {
+                    font-size: 18px !important;
+                    line-height: 24px !important;
+                    width: 290px !important;
+                    display: block;
+                    padding: 0 15px !important;
+                    text-align: center !important;
+                }
+
+                .mobile-header-strong {
+                    font-size: 18px !important;
+                    line-height: 24px !important;
+                }
+
+                .mobile-button,
+                .mobile-footer {
+                    width: 290px !important;
+                    padding: 0 15px !important;
+                    text-align: center !important;
+                }
+
+                .mobile-copy {
+                    font-size: 14px !important;
+                    line-height: 22px !important;
+                    width: 290px !important;
+                    display: block;
+                    padding: 10px 15px !important;
+                    text-align: left !important;
+                }
+
+                .mobile50 {
+                    width: 320px !important;
+                    padding: 0 !important;
+                    text-align: left;
+                }
+
+                *[class="mobileOff"] {
+                    width: 0px !important;
+                    display: none !important;
+                }
+
+                *[class*="mobileOn"] {
+                    display: block !important;
+                    max-height: none !important;
+                }
+            }
+        </style>
+
+        <!--[if gte mso 15]>
+    <style type="text/css">
+        table { font-size:1px; line-height:0; mso-margin-top-alt:1px;mso-line-height-rule: exactly; }
+        * { mso-line-height-rule: exactly; }
+    </style>
+    <![endif]-->
+
+        <!-- Start Background -->
+        <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#E1E1E1" style="table-layout: fixed;">
+            <tbody>
+                <tr>
+                    <td width="100%" valign="top" align="center">
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="wrapper" bgcolor="#E1E1E1">
+                            <tbody>
+                                <tr>
+                                    <td height="20" style="font-size:10px; line-height:10px;"> </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center">
+                                        <!-- Start Container -->
+                                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="container"
+                                            style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td class="mobile" align="center">
+                                                        <img src="https://avatars1.githubusercontent.com/u/6469208?s=280&v=4"
+                                                            width="125" height="125"
+                                                            style="margin:0; padding:0; border:none; display:block;"
+                                                            border="0" class="centerClass" alt="">
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="20" style="font-size:20px; line-height:20px;"> </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" align="center" border="0" class="wrapper"
+                            style="table-layout: fixed;">
+                            <tbody>
+                                <tr>
+                                    <td height="45" bgcolor="#FFFFFF"
+                                        style="border-top-right-radius: 10px;border-top-left-radius: 10px;background-color: #FFFFFF; line-height:45px; font-size:45px; border-top: 1px solid #e1e2e3; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+                                    </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center" bgcolor="#ffffff"
+                                        style="background-color: #FFFFFF; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+
+                                        <!-- Start Container -->
+                                        <table width="540" cellpadding="0" cellspacing="0" align="center" border="0"
+                                            class="container" style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="center" class="mobile-header"
+                                                        style="color: #4F5A63; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:18px; line-height:28px; font-weight: 600;">
+                                                        {{systemUUID}}: <code>{{serverName}}</code>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="10" class="mobileOff"
+                                                        style="line-height:10px; font-size:10px;"> </td><!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td class="mobile-copy" align="left"
+                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 15px; color: #6d7176; line-height:24px;">
+                                                        <p>{{hello}} {{ownerName}},{{{message}}}</p>
+
+                                                    </td>
+                                                </tr>
+
+                                                <tr>
+                                                    <td height="20" style="line-height:20px; font-size:20px;"> </td>
+                                                    <!-- Spacer -->
+                                                </tr>
+
+                                                <tr>
+                                                    <td align="center" class="center mobile-button">
+                                                        <!-- Start Button -->
+                                                        <table width="290" cellpadding="0" cellspacing="0"
+                                                            align="center" border="0">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td width="290" height="55" bgcolor="#00a0dd"
+                                                                        align="center" valign="middle"
+                                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 600; color: #ffffff; line-height:24px; border-radius:5px;">
+                                                                        <a href="{{serverDetails}}" target="_blank"
+                                                                            alias=""
+                                                                            style="display: block; line-height: 55px; margin: 0 auto; font-family: Open Sans, Helvetica, Arial, sans-serif; text-align: center; text-decoration: none; color: #ffffff;">{{serverDetailsMessage}}</a>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                        <!-- End Button -->
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="20" style="line-height:20px; font-size:20px;"> </td>
+                                                    <!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td height="10" class="mobileOff"
+                                                        style="line-height:10px; font-size:10px;"> </td><!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td class="mobile-copy" align="left"
+                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 15px; color: #6d7176; line-height:24px;">
+                                                        <p>{{{footerMessage}}}</p>
+                                                    </td>
+                                                </tr>
+
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="45" bgcolor="#ffffff"
+                                        style="border-bottom-right-radius:10px;border-bottom-left-radius:10px;background-color: #FFFFFF; line-height:45px; font-size:45px; border-bottom: 1px solid #e1e2e3; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+                                    </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="wrapper"
+                            bgcolor="transparent" style="table-layout: fixed;">
+                            <tbody>
+                                <tr>
+                                    <td height="40" style="font-size:40px; line-height:40px;"> </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center">
+
+                                        <!-- Start Container -->
+                                        <table width="540" cellpadding="0" cellspacing="0" border="0" class="container"
+                                            style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td width="540" class="mobile"
+                                                        style="color: #6d7176; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:14px; line-height:20px;"
+                                                        align="center">
+                                                        © {{year}} NethServer Subscription
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="7" style="" class="mobileOn"></td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="7" style="" class="mobileOn"></td>
+                                                </tr>
+                                                <tr>
+                                                    <td width="540" class="mobile-footer"
+                                                        style="color: #6d7176; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:13px; line-height:20px;"
+                                                        align="center">
+                                                        <a href="{{urlComm}}" target="_blank"
+                                                            alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Blog</a>
+                                                        · <a href="{{urlHelp}}" target="_blank" alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Support</a>
+                                                        · <a href="{{urlDocs}}" target="_blank" alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Docs</a>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="20" style="font-size:10px; line-height:10px;"> </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <!-- End Background -->
+
+</body>
+
+
+</body>
+
+</html>

--- a/athos/templates/expiration-template-others.mustache
+++ b/athos/templates/expiration-template-others.mustache
@@ -157,7 +157,7 @@
                                             <tbody>
                                                 <tr>
                                                     <td class="mobile" align="center">
-                                                        <img src="https://avatars1.githubusercontent.com/u/6469208?s=280&v=4"
+                                                        <img src="https://my.nethserver.com/static/android-icon-192x192.png"
                                                             width="125" height="125"
                                                             style="margin:0; padding:0; border:none; display:block;"
                                                             border="0" class="centerClass" alt="">

--- a/athos/templates/expiration-template-trial.mustache
+++ b/athos/templates/expiration-template-trial.mustache
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>{{title}}</title>
+</head>
+
+<body>
+
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <!--[if !mso]><!-->
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <!--<![endif]-->
+
+        <style type="text/css">
+            .ReadMsgBody {
+                width: 100%;
+                background-color: #E1E1E1;
+            }
+
+            .ExternalClass {
+                width: 100%;
+                background-color: #E1E1E1;
+            }
+
+            body {
+                width: 100%;
+                background-color: #E1E1E1;
+                margin: 0;
+                padding: 0;
+                -webkit-font-smoothing: antialiased;
+                font-family: "Open Sans", Helvetica, Arial, sans-serif !important;
+                font-weight: 500;
+            }
+
+            table {
+                border-collapse: collapse !important;
+                mso-table-lspace: 0pt;
+                mso-table-rspace: 0pt;
+            }
+
+            @-ms-viewport {
+                width: device-width;
+            }
+
+            @media only screen and (max-width: 639px) {
+                .wrapper {
+                    width: 100%;
+                    padding: 0 !important;
+                }
+            }
+
+            @media only screen and (max-width: 480px) {
+                .centerClass {
+                    margin: 0 auto !important;
+                }
+
+                .imgClass {
+                    width: 100% !important;
+                    height: auto;
+                }
+
+                .wrapper {
+                    width: 320px !important;
+                    padding: 0 !important;
+                    overflow-x: hidden !important;
+                    border-collapse: separate !important;
+                }
+
+                .container {
+                    width: 320px !important;
+                    padding: 0 !important;
+                }
+
+                .mobile {
+                    width: 320px !important;
+                    display: block;
+                    padding: 0 !important;
+                    text-align: center !important;
+                }
+
+                .mobile-header {
+                    font-size: 18px !important;
+                    line-height: 24px !important;
+                    width: 290px !important;
+                    display: block;
+                    padding: 0 15px !important;
+                    text-align: center !important;
+                }
+
+                .mobile-header-strong {
+                    font-size: 18px !important;
+                    line-height: 24px !important;
+                }
+
+                .mobile-button,
+                .mobile-footer {
+                    width: 290px !important;
+                    padding: 0 15px !important;
+                    text-align: center !important;
+                }
+
+                .mobile-copy {
+                    font-size: 14px !important;
+                    line-height: 22px !important;
+                    width: 290px !important;
+                    display: block;
+                    padding: 10px 15px !important;
+                    text-align: left !important;
+                }
+
+                .mobile50 {
+                    width: 320px !important;
+                    padding: 0 !important;
+                    text-align: left;
+                }
+
+                *[class="mobileOff"] {
+                    width: 0px !important;
+                    display: none !important;
+                }
+
+                *[class*="mobileOn"] {
+                    display: block !important;
+                    max-height: none !important;
+                }
+            }
+        </style>
+
+        <!--[if gte mso 15]>
+    <style type="text/css">
+        table { font-size:1px; line-height:0; mso-margin-top-alt:1px;mso-line-height-rule: exactly; }
+        * { mso-line-height-rule: exactly; }
+    </style>
+    <![endif]-->
+
+        <!-- Start Background -->
+        <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#E1E1E1" style="table-layout: fixed;">
+            <tbody>
+                <tr>
+                    <td width="100%" valign="top" align="center">
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="wrapper" bgcolor="#E1E1E1">
+                            <tbody>
+                                <tr>
+                                    <td height="20" style="font-size:10px; line-height:10px;"> </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center">
+                                        <!-- Start Container -->
+                                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="container"
+                                            style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td class="mobile" align="center">
+                                                        <img src="https://avatars1.githubusercontent.com/u/6469208?s=280&v=4"
+                                                            width="125" height="125"
+                                                            style="margin:0; padding:0; border:none; display:block;"
+                                                            border="0" class="centerClass" alt="">
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="20" style="font-size:20px; line-height:20px;"> </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" align="center" border="0" class="wrapper"
+                            style="table-layout: fixed;">
+                            <tbody>
+                                <tr>
+                                    <td height="45" bgcolor="#FFFFFF"
+                                        style="border-top-right-radius: 10px;border-top-left-radius: 10px;background-color: #FFFFFF; line-height:45px; font-size:45px; border-top: 1px solid #e1e2e3; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+                                    </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center" bgcolor="#ffffff"
+                                        style="background-color: #FFFFFF; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+
+                                        <!-- Start Container -->
+                                        <table width="540" cellpadding="0" cellspacing="0" align="center" border="0"
+                                            class="container" style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td align="center" class="mobile-header"
+                                                        style="color: #4F5A63; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:18px; line-height:28px; font-weight: 600;">
+                                                        {{systemUUID}}: <code>{{serverName}}</code>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="10" class="mobileOff"
+                                                        style="line-height:10px; font-size:10px;"> </td><!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td class="mobile-copy" align="left"
+                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 15px; color: #6d7176; line-height:24px;">
+                                                        <p>{{hello}},{{{message}}}</p>
+
+                                                    </td>
+                                                </tr>
+
+                                                <tr>
+                                                    <td height="20" style="line-height:20px; font-size:20px;"> </td>
+                                                    <!-- Spacer -->
+                                                </tr>
+
+                                                <tr>
+                                                    <td align="center" class="center mobile-button">
+                                                        <!-- Start Button -->
+                                                        <table width="290" cellpadding="0" cellspacing="0"
+                                                            align="center" border="0">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td width="290" height="55" bgcolor="#00a0dd"
+                                                                        align="center" valign="middle"
+                                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 600; color: #ffffff; line-height:24px; border-radius:5px;">
+                                                                        <a href="{{serverDetails}}"
+                                                                            target="_blank" alias=""
+                                                                            style="display: block; line-height: 55px; margin: 0 auto; font-family: Open Sans, Helvetica, Arial, sans-serif; text-align: center; text-decoration: none; color: #ffffff;">{{serverDetailsMessage}}</a>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                        <!-- End Button -->
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="20" style="line-height:20px; font-size:20px;"> </td>
+                                                    <!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td height="10" class="mobileOff"
+                                                        style="line-height:10px; font-size:10px;"> </td><!-- Spacer -->
+                                                </tr>
+                                                <tr>
+                                                    <td class="mobile-copy" align="left"
+                                                        style="font-family: Open Sans, Helvetica, Arial, sans-serif; font-size: 15px; color: #6d7176; line-height:24px;">
+                                                        <p>{{{footerMessage}}}</p>
+                                                    </td>
+                                                </tr>
+
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="45" bgcolor="#ffffff"
+                                        style="border-bottom-right-radius:10px;border-bottom-left-radius:10px;background-color: #FFFFFF; line-height:45px; font-size:45px; border-bottom: 1px solid #e1e2e3; border-left: 1px solid #e1e2e3; border-right: 1px solid #e1e2e3;">
+                                    </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+
+
+                        <!-- Start Wrapper -->
+                        <table width="600" cellpadding="0" cellspacing="0" border="0" class="wrapper"
+                            bgcolor="transparent" style="table-layout: fixed;">
+                            <tbody>
+                                <tr>
+                                    <td height="40" style="font-size:40px; line-height:40px;"> </td><!-- Spacer -->
+                                </tr>
+                                <tr>
+                                    <td align="center">
+
+                                        <!-- Start Container -->
+                                        <table width="540" cellpadding="0" cellspacing="0" border="0" class="container"
+                                            style="table-layout: fixed;">
+                                            <tbody>
+                                                <tr>
+                                                    <td width="540" class="mobile"
+                                                        style="color: #6d7176; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:14px; line-height:20px;"
+                                                        align="center">
+                                                        © {{year}} NethServer Subscription
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="7" style="" class="mobileOn"></td>
+                                                </tr>
+                                                <tr>
+                                                    <td height="7" style="" class="mobileOn"></td>
+                                                </tr>
+                                                <tr>
+                                                    <td width="540" class="mobile-footer"
+                                                        style="color: #6d7176; font-family: Open Sans, Helvetica, Arial, sans-serif; font-size:13px; line-height:20px;"
+                                                        align="center">
+                                                        <a href="{{urlComm}}" target="_blank"
+                                                            alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Blog</a>
+                                                        · <a href="{{urlHelp}}" target="_blank" alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Support</a>
+                                                        · <a href="{{urlDocs}}" target="_blank" alias=""
+                                                            style="font-size:13px; line-height:20px; color:#6d7176; text-decoration:none;">Docs</a>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <!-- End Container -->
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td height="20" style="font-size:10px; line-height:10px;"> </td><!-- Spacer -->
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- End Wrapper -->
+
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <!-- End Background -->
+
+</body>
+
+
+</body>
+
+</html>

--- a/athos/templates/expiration-template-trial.mustache
+++ b/athos/templates/expiration-template-trial.mustache
@@ -157,7 +157,7 @@
                                             <tbody>
                                                 <tr>
                                                     <td class="mobile" align="center">
-                                                        <img src="https://avatars1.githubusercontent.com/u/6469208?s=280&v=4"
+                                                        <img src="https://my.nethserver.com/static/android-icon-192x192.png"
                                                             width="125" height="125"
                                                             style="margin:0; padding:0; border:none; display:block;"
                                                             border="0" class="centerClass" alt="">

--- a/athos/utils/expirations.go
+++ b/athos/utils/expirations.go
@@ -18,25 +18,21 @@
  * along with Dartagnan.  If not, see COPYING.
  *
  */
-
-package notifications
+package utils
 
 import (
+	"fmt"
+
+	"github.com/nethesis/dartagnan/athos/database"
 	"github.com/nethesis/dartagnan/athos/models"
-	"github.com/nethesis/dartagnan/athos/utils"
 )
 
-func AlertNotification(alert models.Alert, isNew bool) {
-	if alert.System.Subscription.SubscriptionPlan.Code == "" {
-		alert.System = utils.GetSystemById(alert.SystemID)
-	}
-	if utils.CanAccessAlerts(alert.System.Subscription.SubscriptionPlan) {
-		switch x := alert.System.Notification["emails"].(type) {
-		case []interface{}:
-			for _, e := range x {
-				MailNotificationAlert(e.(string), alert, isNew)
-			}
-		default:
-		}
-	}
+// List expiration systems in a specific period
+func ListExpirationSystems(period string) []models.System {
+	var systems []models.System
+
+	db := database.Instance()
+	db.Preload("Subscription.SubscriptionPlan").Joins("JOIN subscriptions ON systems.subscription_id = subscriptions.id JOIN subscription_plans ON subscription_plans.id = subscriptions.subscription_plan_id").Where(fmt.Sprintf("date(subscriptions.valid_until)::date = date(date('now') + interval '%s')::date", period)).Find(&systems)
+
+	return systems
 }

--- a/athos/utils/expirations.go
+++ b/athos/utils/expirations.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Nethesis S.r.l.
+ * Copyright (C) 2020 Nethesis S.r.l.
  * http://www.nethesis.it - info@nethesis.it
  *
  * This file is part of Dartagnan project.

--- a/athos/utils/utils.go
+++ b/athos/utils/utils.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/nicksnyder/go-i18n/i18n"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/nethesis/dartagnan/athos/database"
 	"github.com/nethesis/dartagnan/athos/models"
@@ -101,6 +101,15 @@ func Round(val float64, roundOn float64, places int) float64 {
 
 func Contains(intSlice []int, searchInt int) bool {
 	for _, value := range intSlice {
+		if value == searchInt {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsS(stringSlice []string, searchInt string) bool {
+	for _, value := range stringSlice {
 		if value == searchInt {
 			return true
 		}

--- a/deploy/roles/foil/files/expiration.cron
+++ b/deploy/roles/foil/files/expiration.cron
@@ -1,0 +1,14 @@
+#
+# -P period (supported are: 1d, 1w, 2w)
+# -M send mail
+# -Q quiet mode, no output
+#
+
+# expiration in 1 day
+5 2 * * * root /opt/dartagnan/foil expirations -P 1d -M -Q
+
+# expiration in 1 week
+15 2 * * * root /opt/dartagnan/foil expirations -P 1w -M -Q
+
+# expiration in 2 weeks
+20 2 * * * root /opt/dartagnan/foil expirations -P 2w -M -Q

--- a/foil/cmd/expirations.go
+++ b/foil/cmd/expirations.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2018 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * This file is part of Dartagnan project.
+ *
+ * Dartagnan is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Dartagnan is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Dartagnan.  If not, see COPYING.
+ *
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nethesis/dartagnan/athos/notifications"
+	"github.com/nethesis/dartagnan/athos/utils"
+	"github.com/spf13/cobra"
+)
+
+var period string
+var sendMail bool
+var quietMode bool
+
+var expirationsCmd = &cobra.Command{
+	Use:   "expirations",
+	Short: "List expiration systems by period (default expire in 1 day)",
+	Long: `List all systems that expire in a specified period (default expire in 1 day)
+
+	 Examples
+
+	 List expiration systems by period (default expire in 1 day)
+		foil expirations -P 1d
+
+	 List expiration systems by period and send expiration mail to systems owners (default expire in 1 day)
+		foil expirations -P 1d -M
+
+
+	 Supported periods:
+	 - 1d (1 day)
+	 - 1w (1 week)
+	 - 2w (2 week) (only for trials)
+
+	 `,
+	Run: getExpireSystems,
+}
+
+func getExpireSystems(cmd *cobra.Command, args []string) {
+	if !utils.ContainsS([]string{"1d", "1w", "2w"}, period) {
+		fmt.Println(`Unsupported period.
+
+Supported periods:
+- 1d (1 day)
+- 1w (1 week)
+- 2w (2 week) (only for trials)
+		`)
+		os.Exit(1)
+	}
+
+	systems := utils.ListExpirationSystems(period)
+
+	// prints results header
+	if !quietMode {
+		fmt.Printf("System\t\t\t\t\tUser\t\t\t\t\tSubscription\tSubscription End\tEmail\t\n\n")
+	}
+
+	for _, system := range systems {
+		if system.Subscription.SubscriptionPlan.Code != "trial" && period == "2w" {
+			// skip not trial in 2 weeks
+			continue
+		}
+		// print results as command output
+		if !quietMode {
+			until := fmt.Sprintf("%d-%02d-%02d", system.Subscription.ValidUntil.Year(), system.Subscription.ValidUntil.Month(), system.Subscription.ValidUntil.Day())
+			fmt.Printf("%-40v%-40v%-16v%-15v\t\t%s\n", system.UUID, system.CreatorID, system.Subscription.SubscriptionPlan.Code, until, system.Notification["emails"])
+		}
+
+		// send mail to owners
+		if sendMail {
+			switch x := system.Notification["emails"].(type) {
+			case []interface{}:
+				for _, e := range x {
+					notifications.MailNotificationExpire(e.(string), system, period)
+				}
+			default:
+			}
+		}
+
+	}
+}
+
+func init() {
+	expirationsCmd.Flags().StringVarP(&period, "period", "P", "1d", "Period of expiration")
+	expirationsCmd.Flags().BoolVarP(&sendMail, "send-mail", "M", false, "Send expiration mail to system owners")
+	expirationsCmd.Flags().BoolVarP(&quietMode, "quiet-mode", "Q", false, "Do not print results (Used with -M flag)")
+
+	rootCmd.AddCommand(expirationsCmd)
+}

--- a/foil/cmd/expirations.go
+++ b/foil/cmd/expirations.go
@@ -64,7 +64,7 @@ func getExpireSystems(cmd *cobra.Command, args []string) {
 Supported periods:
 - 1d (1 day)
 - 1w (1 week)
-- 2w (2 week) (only for trials)
+- 2w (2 weeks) (only for trials)
 		`)
 		os.Exit(1)
 	}

--- a/foil/cmd/expirations.go
+++ b/foil/cmd/expirations.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Nethesis S.r.l.
+ * Copyright (C) 2020 Nethesis S.r.l.
  * http://www.nethesis.it - info@nethesis.it
  *
  * This file is part of Dartagnan project.

--- a/foil/cmd/expirations.go
+++ b/foil/cmd/expirations.go
@@ -51,7 +51,7 @@ var expirationsCmd = &cobra.Command{
 	 Supported periods:
 	 - 1d (1 day)
 	 - 1w (1 week)
-	 - 2w (2 week) (only for trials)
+	 - 2w (2 weeks) (only for trials)
 
 	 `,
 	Run: getExpireSystems,


### PR DESCRIPTION
`foil` binary now supports `expirations` command. It's used to list, for a specific expiration period, systems and subscription that are in expiration. 

Supported periods:
- 1d (1 day)
- 1w (1 week)
- 2w (2 week) (only for trials)

Every day a scheduled cron sends emails to the owners of the systems to inform them of the expiration of the subscription.

Ex.
```bash
foil expirations -P 1d -M
```

The command above get all the subscription that expire the next day (`1d`) and sends the mail (with `-M` flag) to the owners.

For **trial** subscriptions, `foil` sends mails when the expiration is in 2 weeks, 1 weeks and 1 day, with different messages to upgrade to a paid plan.

For **others** subscriptions, `foil` sends mails when the expiration is in 1 week and 1 day to suggest to the user to renew the plan.