### PR TITLE
Ignore Porthos upstream rsync permissions

### DIFF
--- a/porthos/root/usr/local/bin/xrsync
+++ b/porthos/root/usr/local/bin/xrsync
@@ -27,9 +27,12 @@ dest=$1 ; shift
 source /etc/porthos/xrsync.conf
 
 function exithandler() {
-    # If exit code is non-zero, copy error file contents to stderr
     if [[ $? != 0 ]]; then
-        cat "${tmperr}" >&2
+        # If exit code is non-zero, copy error file contents to syslog and stderr
+        logger -t xrsync -s -f "${tmperr}"
+    else
+        # Log to syslog only
+        logger -t xrsync -f "${tmperr}"
     fi
     rm -f "${tmperr}"
 }
@@ -60,6 +63,7 @@ for ((I=1; I <= attempts; I++)); do
     rsync -aqSH --no-super --no-perms --chmod=ugo=rwX --no-g --no-o "${@}" "${src}" "${dest}" 2>>"${tmperr}"
     ret_rsync=$?
     if [[ $ret_rsync == 0 ]]; then
+        echo "sync-success from ${src} to ${dest}" >>"${tmperr}"
         exit 0
     elif [[ $ret_rsync == 1 ]]; then
         echo "[ERROR] rsync bad syntax" >>"${tmperr}"

--- a/porthos/root/usr/local/bin/xrsync
+++ b/porthos/root/usr/local/bin/xrsync
@@ -57,7 +57,7 @@ fi
 for ((I=1; I <= attempts; I++)); do
     src_id=$(( (src_seed + I) % ${#src_list[@]} ))
     src="${src_list[$src_id]}${poolp}"
-    rsync -aqSH --no-super --no-g --no-o "${@}" "${src}" "${dest}" 2>>"${tmperr}"
+    rsync -aqSH --no-super --no-perms --chmod=ugo=rwX --no-g --no-o "${@}" "${src}" "${dest}" 2>>"${tmperr}"
     ret_rsync=$?
     if [[ $ret_rsync == 0 ]]; then
         exit 0


### PR DESCRIPTION
See the rsync (1) manpage

> To give new files the destination-default permissions (while leaving existing files unchanged), make sure that the --perms option is off and  use  --chmod=ugo=rwX  (which  ensures  that  all  non-masked  bits  get enabled)